### PR TITLE
Bugs fixed: GC ows:reference SOS 2.0.0, and GO temporalFilter SOS 2.0.0

### DIFF
--- a/istsoslib/filters/GO_filter.py
+++ b/istsoslib/filters/GO_filter.py
@@ -158,7 +158,7 @@ class sosGOfilter(f.sosFilter):
                 #     - combination:  temporalFilter=om:phenomenonTime,2012-11-19T14:00:00+01:00/2012-11-19T14:15:00+01:00,2012-11-19T14:00:00.000+01:00
                 if requestObject.has_key('temporalfilter'):
                     self.eventTime = []
-                    temporalfilter = requestObject["temporalfilter"].split(",")
+                    temporalfilter = requestObject["temporalfilter"].replace(" ","+").split(",")
                     
                     #  > in istSOS om:phenomenonTime is equals to om:resultTime
                     if temporalfilter.pop(0) not in ['om:phenomenonTime','phenomenonTime','om:resultTime','resultTime']:

--- a/istsoslib/renderers/GCresponseRender.py
+++ b/istsoslib/renderers/GCresponseRender.py
@@ -294,7 +294,7 @@ def render_2_0_0(GC,sosConfig):
                 r += "      </ows:AllowedValues>\n"
                 # add ReferenceSystem tag
                 if p.referenceSystem:
-                    r += "      <ows:ReferenceSystem reference='" + str(p.referenceSystem) + "' />\n"
+                    r += "      <ows:ReferenceSystem ows:reference='" + str(p.referenceSystem) + "' />\n"
                 r += "    </ows:Parameter>\n"
                 
             if o.name != 'GlobalOperations':


### PR DESCRIPTION
In the GC response of the SOS 2.0.0 I changed the attribute of the ows:ReferenceSystem element from reference to ows:reference.

In the temporalFilter parameter of the GO KVP request (SOS 2.0.0) I added the same control on the date used in the eventTime parameter of the SOS 1.0.0 GO.